### PR TITLE
noDockOnStop -> DockOnStop

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ configure your accessory using JSON:
 |`runningContactSensor`|Add a contact sensor to HomeKit that's _open_ when Roomba is running|
 |`binContactSensor`|Add a contact sensor to HomeKit that's _open_ when Roomba's bin is full|
 |`dockingContactSensor`|Add a contact sensor to HomeKit that's _open_ when Roomba is docking|
-|`noDockOnStop`|Do not send home when stopped|
+|`DockOnStop`|Sends roomba home to dock when stopped|
 
 ### Deprecated configuration
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -55,9 +55,10 @@
                 "title": "Show docking status as a contact sensor",
                 "required": false
             },
-            "noDockOnStop": {
+            "DockOnStop": {
                 "type": "boolean",
-                "title": "Do not send home when stopped",
+                "title": "Send home when stopped",
+                "default": true,
                 "required": false
             }
         }

--- a/config.schema.json
+++ b/config.schema.json
@@ -57,7 +57,7 @@
             },
             "DockOnStop": {
                 "type": "boolean",
-                "title": "Send home when stopped",
+                "title": "Dock when stopped",
                 "default": true,
                 "required": false
             }

--- a/src/accessory.ts
+++ b/src/accessory.ts
@@ -76,7 +76,7 @@ export default class RoombaAccessory implements AccessoryPlugin {
     private robotpwd: string
     private ipaddress: string
     private firmware: string
-    private noDockOnStop: boolean
+    private DockOnStop: boolean
 
     private accessoryInfo: Service
     private filterMaintenance: Service
@@ -128,7 +128,7 @@ export default class RoombaAccessory implements AccessoryPlugin {
         this.robotpwd = config.robotpwd;
         this.ipaddress = config.ipaddress;
         this.firmware = "N/A";
-        this.noDockOnStop = config.noDockOnStop;
+        this.DockOnStop = config.DockOnStop;
 
         const showDockAsContactSensor = config.dockContactSensor === undefined ? true : config.dockContactSensor;
         const showRunningAsContactSensor = config.runningContactSensor;
@@ -431,8 +431,13 @@ export default class RoombaAccessory implements AccessoryPlugin {
 
                     if (state.running) {
                         this.log("Roomba is pausing");
-
                         await roomba.pause();
+                        if (this.DockOnStop) {
+                            this.log("Roomba paused, returning to Dock");
+                            await this.dockWhenStopped(roomba, 3000);
+                        } else {
+                            this.log("Roomba is paused");
+                        }
 
                         callback();
                         
@@ -442,12 +447,6 @@ export default class RoombaAccessory implements AccessoryPlugin {
                             docking: false,
                         });
 
-                        if (!this.noDockOnStop) {
-                            this.log("Roomba paused, returning to Dock");
-                            await this.dockWhenStopped(roomba, 3000);
-                        } else {
-                            this.log("Roomba is paused");
-                        }
                     } else if (state.docking) {
                         this.log("Roomba is docking");
                         await roomba.pause();


### PR DESCRIPTION
Reverses logic. DockOnStop = True is default and will send the Roomba home to dock when the accessory is turned off.